### PR TITLE
Improve addition of Java to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,35 @@
-FROM ubuntu:bionic
+ARG DOWNLOAD_URI=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_linux_hotspot_11.0.4_11.tar.gz
+ARG SHA256=70d2cc675155476f1d8516a7ae6729d44681e4fad5a6fc8dfa65cab36a67b7e0
+
+# Download and verify file
+# Args: $DOWNLOAD_URI, $SHA256
+FROM ubuntu:bionic AS retrieve
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates \
     curl \
-    netcat \
-    wget \
  && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /opt/openjdk
+ARG DOWNLOAD_URI
+RUN curl -L \
+    $DOWNLOAD_URI \
+    > download.tar.gz
+
+ARG SHA256
+RUN echo "${SHA256} download.tar.gz" | sha256sum -c - 2>&1
+
+# Install File
+FROM ubuntu:bionic
+
+ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH
 
 COPY wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh
 
-RUN mkdir -p /opt/openjdk \
- && cd /opt/openjdk \
- && curl https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/openjdk-1.8.0_192.tar.gz | tar xz
+COPY --from=retrieve download.tar.gz /tmp/download.tar.gz
+
+RUN mkdir -p $JAVA_HOME \
+ && cd $JAVA_HOME \
+ && tar xzf /tmp/download.tar.gz --strip-components=1 \
+ && rm /tmp/download.tar.gz


### PR DESCRIPTION
Previously, the Docker file added a bunch of utilities and downloaded the version of Java directly in the image that was eventually created.  This left a bunch of unnecessary and potentially vulnerable packages on the image that was used in production.  This change makes the build a multi-stage build and ensures that the network utilities required for downloading only exist on a disposed stage.

In addition to the change to a multi-stage build, this change also swaps from the Pivotal Distribution of OpenJDK to AdoptOpenJDK as part of our commitment to move to an industry standard distribution.  It also swaps from Java 8 to Java 11.  Trust me, you'll be fine.