### PR TITLE
Linting dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ENV PATH $JAVA_HOME/bin:$PATH
 COPY wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh
 
-RUN mkdir -p /opt/openjdk \
- && cd /opt/openjdk \
- && curl https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/openjdk-1.8.0_192.tar.gz | tar xz
+WORKDIR /opt/openjdk
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/openjdk-1.8.0_192.tar.gz | tar xz


### PR DESCRIPTION
Removing `mkdir` command in favor of `WORKDIR` dockerfile instruction and also adding pipefail option before invoke a `RUN` instruction using pipes

https://docs.docker.com/engine/reference/builder/#workdir
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#using-pipes